### PR TITLE
Webpack dev server improvements.

### DIFF
--- a/packages/generator-teams/CHANGELOG.md
+++ b/packages/generator-teams/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [*Unreleased*]- <>
+
+### Changes
+
+* `webpack.config.js` contains default settings for the webpack-dev-server (PR #251 by s-KaiNet)
+
 ## [*3.3.1*]- <*2021-10-08*>
 
 ### Changes

--- a/packages/generator-teams/src/app/templates/webpack.config.js
+++ b/packages/generator-teams/src/app/templates/webpack.config.js
@@ -104,14 +104,11 @@ const config = [{
         port: 9000,
         allowedHosts: "all",
         client: {
-            overlay: debug
-                ? {
-                    warnings: false,
-                    errors: true
-                }
-                : false
+            overlay: {
+              warnings: false,
+              errors: true
+          }
         },
-        liveReload: debug,
         devMiddleware: {
             writeToDisk: true,
             stats: {

--- a/packages/generator-teams/src/app/templates/webpack.config.js
+++ b/packages/generator-teams/src/app/templates/webpack.config.js
@@ -97,7 +97,33 @@ const config = [{
                 configFile: "./src/client/tsconfig.json"
             }
         })
-    ]
+    ],
+    devServer: {
+        hot: false,
+        host: "localhost",
+        port: 9000,
+        allowedHosts: "all",
+        client: {
+            overlay: debug
+                ? {
+                    warnings: false,
+                    errors: true
+                }
+                : false
+        },
+        liveReload: debug,
+        devMiddleware: {
+            writeToDisk: true,
+            stats: {
+                all: false,
+                colors: true,
+                errors: true,
+                warnings: true,
+                timings: true,
+                entrypoints: true
+            }
+        }
+    }
 }
 ];
 <% if (lintingSupport) { %>

--- a/packages/yoteams-build-core/CHANGELOG.md
+++ b/packages/yoteams-build-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [*Unreleased*]- <>
+
+### Changes
+
+* Webpack dev server now runs only in `--debug` mode, added webpack dev server "compilation starting" notification message (PR #251 by s-KaiNet)
+
 ## [*1.3.0*]- <*2021-09-30*>
 
 ### Added

--- a/packages/yoteams-build-core/src/webpackServe.ts
+++ b/packages/yoteams-build-core/src/webpackServe.ts
@@ -12,7 +12,7 @@ import path from "path";
     const compiler = Webpack(clientConfig);
 
     compiler.hooks.beforeCompile.tap("webpackServe", () => {
-        console.log("webpack compiling");
+        log.info("webpack compiling");
     });
 
     const defaultDevServerConfig = {

--- a/packages/yoteams-build-core/src/webpackServe.ts
+++ b/packages/yoteams-build-core/src/webpackServe.ts
@@ -15,7 +15,30 @@ import path from "path";
         console.log("webpack compiling");
     });
 
-    const server = new WebpackDevServer(clientConfig.devServer, compiler);
+    const defaultDevServerConfig = {
+        hot: false,
+        host: "localhost",
+        port: 9000,
+        allowedHosts: "all",
+        client: {
+            overlay: {
+                warnings: false,
+                errors: true
+            }
+        },
+        devMiddleware: {
+            writeToDisk: true,
+            stats: {
+                all: false,
+                colors: true,
+                errors: true,
+                warnings: true,
+                timings: true,
+                entrypoints: true
+            }
+        }
+    };
+    const server = new WebpackDevServer(clientConfig.devServer || defaultDevServerConfig, compiler);
 
     try {
         await server.start();

--- a/packages/yoteams-build-core/src/webpackServe.ts
+++ b/packages/yoteams-build-core/src/webpackServe.ts
@@ -8,24 +8,14 @@ import path from "path";
 
 (async () => {
     const webpackConfig = require(path.join(process.cwd(), "webpack.config"));
-    const compiler = Webpack(webpackConfig[1]);
-    const server = new WebpackDevServer({
-        hot: false,
-        host: "localhost",
-        port: 9000,
-        allowedHosts: "all",
-        devMiddleware: {
-            writeToDisk: true,
-            stats: {
-                all: false,
-                colors: true,
-                errors: true,
-                warnings: true,
-                timings: true,
-                entrypoints: true
-            }
-        }
-    }, compiler);
+    const clientConfig = webpackConfig[1];
+    const compiler = Webpack(clientConfig);
+
+    compiler.hooks.beforeCompile.tap("webpackServe", () => {
+        console.log("webpack compiling");
+    });
+
+    const server = new WebpackDevServer(clientConfig.devServer, compiler);
 
     try {
         await server.start();


### PR DESCRIPTION
Based on the outcome of the discussion [here](https://github.com/pnp/generator-teams/discussions/248#discussioncomment-1465530): 

- `devServer` options were moved to the `webpack.client.js`
- notification about starting the compilation

Also:
- during `-serve` without `--debug` liveReload and overlay for devServer is disabled (otherwise it creates very strange issues like infinite page reloading)
- I could not disable `webpack:client` in `--debug` mode, because another task `static:inject` depends on the output from `webpack:client`. When `webpack:client` is disabled, `static:inject` will produce the wrong output and will break everything (though the build looks ok, the app doesn't work)

/cc @pschaeflein 